### PR TITLE
feat: add feature showcase component

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,8 +2,6 @@ name: Chromatic
 
 on:
   pull_request:
-    branches:
-      - master
   push:
     branches:
       - master

--- a/src/FeatureShowcase.tsx
+++ b/src/FeatureShowcase.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+
+interface FeatureShowcaseItem {
+  label: string;
+  title: string;
+  description: string;
+}
+
+interface FeatureShowcaseMetric {
+  label: string;
+  value: string;
+}
+
+interface FeatureShowcaseAction {
+  label: string;
+  href: string;
+}
+
+interface FeatureShowcaseProps {
+  title: string;
+  description: string;
+  eyebrow?: string;
+  features: FeatureShowcaseItem[];
+  metrics?: FeatureShowcaseMetric[];
+  primaryAction?: FeatureShowcaseAction;
+  secondaryAction?: FeatureShowcaseAction;
+  accentColor?: string;
+  tone?: 'light' | 'dark';
+  density?: 'comfortable' | 'compact';
+}
+
+const styles = {
+  shell: {
+    border: '1px solid #d1d5db',
+    borderRadius: '8px',
+    boxShadow: '0 18px 48px rgba(15, 23, 42, 0.12)',
+    display: 'grid',
+    gap: '24px',
+    overflow: 'hidden',
+    width: '920px',
+  },
+  hero: {
+    display: 'grid',
+    gap: '18px',
+  },
+  eyebrow: {
+    fontSize: '0.75rem',
+    fontWeight: 700,
+    margin: 0,
+    textTransform: 'uppercase',
+  },
+  title: {
+    fontSize: '2rem',
+    fontWeight: 800,
+    letterSpacing: 0,
+    lineHeight: 1.1,
+    margin: 0,
+  },
+  description: {
+    fontSize: '1rem',
+    lineHeight: 1.6,
+    margin: 0,
+    maxWidth: '620px',
+  },
+  actions: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '10px',
+  },
+  action: {
+    alignItems: 'center',
+    borderRadius: '6px',
+    display: 'inline-flex',
+    fontSize: '0.9rem',
+    fontWeight: 700,
+    justifyContent: 'center',
+    minHeight: '40px',
+    padding: '0 14px',
+    textDecoration: 'none',
+  },
+  metricGrid: {
+    display: 'grid',
+    gap: '10px',
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+  },
+  metric: {
+    borderRadius: '8px',
+    padding: '14px',
+  },
+  metricValue: {
+    fontSize: '1.5rem',
+    fontWeight: 800,
+    lineHeight: 1,
+    margin: '0 0 6px',
+  },
+  metricLabel: {
+    fontSize: '0.8rem',
+    lineHeight: 1.35,
+    margin: 0,
+  },
+  featureGrid: {
+    display: 'grid',
+    gap: '12px',
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+  },
+  feature: {
+    borderRadius: '8px',
+    padding: '16px',
+  },
+  featureLabel: {
+    alignItems: 'center',
+    borderRadius: '999px',
+    display: 'inline-flex',
+    fontSize: '0.75rem',
+    fontWeight: 800,
+    height: '28px',
+    justifyContent: 'center',
+    marginBottom: '12px',
+    minWidth: '28px',
+    padding: '0 9px',
+  },
+  featureTitle: {
+    fontSize: '1rem',
+    fontWeight: 800,
+    lineHeight: 1.25,
+    margin: '0 0 8px',
+  },
+  featureDescription: {
+    fontSize: '0.9rem',
+    lineHeight: 1.5,
+    margin: 0,
+  },
+} as const;
+
+export const FeatureShowcase: React.FC<FeatureShowcaseProps> = ({
+  title,
+  description,
+  eyebrow,
+  features,
+  metrics,
+  primaryAction,
+  secondaryAction,
+  accentColor = '#0f766e',
+  tone = 'light',
+  density = 'comfortable',
+}) => {
+  const isDark = tone === 'dark';
+  const padding = density === 'compact' ? '24px' : '32px';
+  const background = isDark ? '#111827' : '#ffffff';
+  const surface = isDark ? '#1f2937' : '#f9fafb';
+  const border = isDark ? '#374151' : '#e5e7eb';
+  const text = isDark ? '#f9fafb' : '#111827';
+  const mutedText = isDark ? '#d1d5db' : '#4b5563';
+  const subtleText = isDark ? '#9ca3af' : '#6b7280';
+
+  return (
+    <section
+      style={{
+        ...styles.shell,
+        background,
+        borderColor: border,
+        color: text,
+        padding,
+      }}
+    >
+      <div style={styles.hero}>
+        {eyebrow && <p style={{ ...styles.eyebrow, color: accentColor }}>{eyebrow}</p>}
+        <h2 style={styles.title}>{title}</h2>
+        <p style={{ ...styles.description, color: mutedText }}>{description}</p>
+        {(primaryAction || secondaryAction) && (
+          <div style={styles.actions}>
+            {primaryAction && (
+              <a
+                href={primaryAction.href}
+                style={{
+                  ...styles.action,
+                  backgroundColor: accentColor,
+                  border: `1px solid ${accentColor}`,
+                  color: '#ffffff',
+                }}
+              >
+                {primaryAction.label}
+              </a>
+            )}
+            {secondaryAction && (
+              <a
+                href={secondaryAction.href}
+                style={{
+                  ...styles.action,
+                  backgroundColor: 'transparent',
+                  border: `1px solid ${border}`,
+                  color: text,
+                }}
+              >
+                {secondaryAction.label}
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+
+      {metrics && metrics.length > 0 && (
+        <div style={styles.metricGrid}>
+          {metrics.map((metric) => (
+            <div key={metric.label} style={{ ...styles.metric, backgroundColor: surface, border: `1px solid ${border}` }}>
+              <p style={{ ...styles.metricValue, color: text }}>{metric.value}</p>
+              <p style={{ ...styles.metricLabel, color: subtleText }}>{metric.label}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div style={styles.featureGrid}>
+        {features.map((feature) => (
+          <article key={feature.title} style={{ ...styles.feature, backgroundColor: surface, border: `1px solid ${border}` }}>
+            <span
+              style={{
+                ...styles.featureLabel,
+                backgroundColor: `${accentColor}1a`,
+                color: accentColor,
+              }}
+            >
+              {feature.label}
+            </span>
+            <h3 style={styles.featureTitle}>{feature.title}</h3>
+            <p style={{ ...styles.featureDescription, color: mutedText }}>{feature.description}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { BlogCard } from './BlogCard';
 export { EqualSpacingGrid } from './EqualSpacingGrid';
 export { BlogCardWithSections } from './BlogCardWithSections';
+export { FeatureShowcase } from './FeatureShowcase';

--- a/src/stories/FeatureShowcase.stories.tsx
+++ b/src/stories/FeatureShowcase.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FeatureShowcase } from '../FeatureShowcase';
+
+const features = [
+  {
+    label: '01',
+    title: 'Dependency aware layout',
+    description: 'Group related UI blocks with predictable spacing, borders, and scanning order.',
+  },
+  {
+    label: '02',
+    title: 'Decision-ready metrics',
+    description: 'Surface the numbers that matter without forcing teams into a dashboard shell.',
+  },
+  {
+    label: '03',
+    title: 'Flexible actions',
+    description: 'Pair a primary command with a secondary link while keeping the component self-contained.',
+  },
+];
+
+const metrics = [
+  { label: 'Reusable sections', value: '12' },
+  { label: 'Bundle dependencies', value: '0' },
+  { label: 'Theme variants', value: '2' },
+];
+
+const meta = {
+  title: 'Marketing/FeatureShowcase',
+  component: FeatureShowcase,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    accentColor: { control: 'color' },
+    density: { control: 'inline-radio' },
+    tone: { control: 'inline-radio' },
+  },
+} satisfies Meta<typeof FeatureShowcase>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ProductOverview: Story = {
+  args: {
+    eyebrow: 'Component release',
+    title: 'A full showcase block for feature-rich product pages',
+    description:
+      'FeatureShowcase combines a concise header, supporting metrics, and structured feature cards for product or documentation pages.',
+    features,
+    metrics,
+    primaryAction: { label: 'View package', href: 'https://www.npmjs.com/package/deps-less-ui' },
+    secondaryAction: { label: 'Read docs', href: 'https://nash1111.github.io/deps-less-ui/' },
+    accentColor: '#0f766e',
+  },
+};
+
+export const DarkLaunch: Story = {
+  args: {
+    ...ProductOverview.args,
+    eyebrow: 'Launch notes',
+    title: 'Highlight a release with strong contrast',
+    description:
+      'The dark tone gives release pages, changelogs, and internal launch notes a stronger visual anchor.',
+    tone: 'dark',
+    accentColor: '#22c55e',
+  },
+};
+
+export const CompactOperations: Story = {
+  args: {
+    ...ProductOverview.args,
+    eyebrow: 'Operations',
+    title: 'Compact mode for dense internal pages',
+    description:
+      'Use compact density when the showcase needs to sit near tables, changelogs, or comparison content.',
+    density: 'compact',
+    accentColor: '#2563eb',
+  },
+};


### PR DESCRIPTION
## Summary
- Add a new FeatureShowcase component with hero copy, metrics, actions, and feature cards.
- Add Storybook coverage for light, dark, and compact showcase variants.
- Let the Chromatic workflow run on stacked pull requests so this change can produce its own UI comparison.

## Validation
- pnpm build
- pnpm lint
- pnpm build-storybook

## Notes
This pull request is stacked on #17 so the UI comparison focuses on the new showcase component instead of repeating the Chromatic setup diff.